### PR TITLE
ENH: Support Slicer integration enabling manylinux_2_17_x86_64 wheels build

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -9,6 +9,6 @@ jobs:
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
     with:
-      manylinux-platforms: '["_2_28-x64","_2_28-aarch64"]'
+      manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
     secrets:
       pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This ensures that installed itk-ants wheels have been build with `_GLIBCXX_USE_CXX11_ABI=0` to match the ABI also used to build Slicer official binaries.

For more details, see https://github.com/Slicer/Slicer/pull/8168